### PR TITLE
FLUT-890139 - [Others] Updated http version because of dependabot issue.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   sqflite: ^1.3.2+3
   path_provider: ^1.6.27
   intl: ^0.16.0
-  http: "0.11.3+17"
+  http: ^0.13.3
   date_format: ^1.0.8
   connectivity: ^0.3.0
 


### PR DESCRIPTION
## Description ##

The dependabot alerts the following issues in the GitHub repository.
- The issue is http version before 0.13.3 vulnerable to header injection.


So, we changed the http version to 0.13.3 in the pubspec.yaml file to avoid vulnerability to the repository.